### PR TITLE
Fix: Ensure messages array is not empty for new chats

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -312,7 +312,13 @@ export const fetchResponse = async (
 
   // Prepare messages for conversation history, ensuring we respect context limits
   // Needed for both command handler fallback (potentially) and standard LLM calls
-  const truncatedMessages = truncateConversationHistory(messages, selectedModel);
+  const currentUserMessage: Message = {
+    id: `user-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`, // Simple unique ID
+    role: 'user',
+    content: finalInput, // Use finalInput which includes scraped content if available
+  };
+  const updatedMessagesWithCurrentInput = [...messages, currentUserMessage];
+  const truncatedMessages = truncateConversationHistory(updatedMessagesWithCurrentInput, selectedModel);
   
   let response;
 


### PR DESCRIPTION
I modified `app/api/apiService.ts` to correctly include your current message in the `messages` array that is processed and sent to the backend API (`/api/ai`).

Previously, when a new chat was started, the `messages` array passed to `fetchResponse` was empty, and your current input was not added to this array before it was potentially truncated and sent to the Vercel AI SDK. This resulted in a "Invalid prompt: messages must not be empty" error.

The `fetchResponse` function now constructs a `Message` object from your current input and adds it to the conversation history before any truncation logic is applied. This ensures that the backend always receives a non-empty messages array, resolving the error for new chat sessions.